### PR TITLE
Expands ls_inst_files variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: installing oracle client
   sudo: true
   unarchive: src={{ item }} dest={{ oracle_client_base }}
-  with_items: ls_inst_files.stdout_lines
+  with_items: "{{ ls_inst_files.stdout_lines }}"
   tags: install
 
 - name: obtaining installation directory


### PR DESCRIPTION
Tested under Ansible 2.3, fixes error:
"Unable to find 'ls_inst_files.stdout_lines' in expected paths."